### PR TITLE
fix: check status when call `exitFullscreen`

### DIFF
--- a/src/component.vue
+++ b/src/component.vue
@@ -65,7 +65,7 @@
         requestFullscreen(this.$el)
       },
       exit () {
-        if (!this.supportFullScreen) {
+        if (!this.supportFullScreen || !this.getState()) {
           return
         }
         exitFullscreen()


### PR DESCRIPTION
When upgraded to Chrome 71+, user click the component which not in fullscreen mode will report error `Uncaught (in promise) TypeError: Document not active`, so we need check the status before call the `exitFullscreen` function.