### PR TITLE
fix: fix typescript typings after relocation

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,5 @@
+import Vue from "vue";
+
 type VueFullScreenOptions = {
   callback?: (fullscreen: boolean) => void;
   fullscreenClass?: string;
@@ -5,8 +7,7 @@ type VueFullScreenOptions = {
   exitOnClickWrapper?: boolean;
   background?: string;
 };
-
-interface VueFullscreen {
+declare class VueFullscreen {
   toggle(
     target: Element,
     options?: VueFullScreenOptions,
@@ -18,4 +19,9 @@ interface VueFullscreen {
   support: boolean;
 }
 
-export default VueFullscreen;
+export declare function install(vue: typeof Vue, url: string): void;
+declare module "vue/types/vue" {
+  interface Vue {
+    $fullscreen: VueFullscreen;
+  }
+}


### PR DESCRIPTION
While testing the types in my local branch in jellyfin-vue, somehow everything worked right and it autocompleted everything, so didn't bother to actually build the client and see if the types were working properly.

I think VSCode cached the local typings instead of the package's ones somehow so it didn't report any error, as I didn't close and reopen it.

Also, perhaps the location change messed things somehow.

Either way, this fixes the import of the package and the use with ``Vue.use`` as you state in the docs in TypeScript environments (JS ones were unaffected)