### PR TITLE
Fullscreen types and JSDoc

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,11 +9,11 @@ type VueFullScreenOptions = {
 };
 declare class VueFullscreen {
   toggle(
-    target: Element,
+    target?: Element,
     options?: VueFullScreenOptions,
     force?: boolean | undefined
   ): void;
-  enter(target: Element, options?: VueFullScreenOptions): void;
+  enter(target?: Element, options?: VueFullScreenOptions): void;
   exit(): void;
   getState(): boolean;
   support: boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,14 +8,36 @@ type VueFullScreenOptions = {
   background?: string;
 };
 declare class VueFullscreen {
+  /**
+   * Attempts to toggle fullscreen using the target element
+   *
+   * @param target - Target element to enter fullscreen, defaults to `document.body`
+   * @param options - The fullscreen options
+   * @param force - `true` to force enter, `false` to exit fullscreen
+   */
   toggle(
     target?: Element,
     options?: VueFullScreenOptions,
     force?: boolean | undefined
   ): void;
+  /**
+   * Attempts to enter fullscreen using the target element
+   *
+   * @param target - Target element to enter fullscreen, defaults to `document.body`
+   * @param options - The fullscreen options
+   */
   enter(target?: Element, options?: VueFullScreenOptions): void;
+  /**
+   * Exits fullscreen
+   */
   exit(): void;
+  /**
+   * Gets the fullscreen state
+   */
   getState(): boolean;
+  /**
+   * Check browser support for the fullscreen API
+   */
   support: boolean;
 }
 


### PR DESCRIPTION
Thanks for this Vue Plugin, it works great. I really appreciate you working on getting types in as quickly as possible. This PR is slightly unnecessary, but it fixes 2 minor issues, and adds some JSDoc comments.

To tidy up what ferferga has done I have:

 - Make `target` optional (it defaults to document.body)
 - Added JSDoc info for all functions in the types file (`index.d.ts`)


![image](https://user-images.githubusercontent.com/18101008/113718663-c662b680-96e4-11eb-9f75-10af21334501.png)
